### PR TITLE
Allow sub-Gb DRAM size.

### DIFF
--- a/parser/TechnologyValues.cpp
+++ b/parser/TechnologyValues.cpp
@@ -259,7 +259,7 @@ TechnologyValues::readjson(const std::string& t,const std::string& p)
     //size of DRAM
     assert(paradocument.HasMember("Size"));
     assert(paradocument["Size"].IsNumber()); 
-    dramsize = paradocument["Size"].GetInt();
+    dramsize = paradocument["Size"].GetDouble();
 
     //# of banks
     assert(paradocument.HasMember("Numberofbanks"));

--- a/parser/TechnologyValues.h
+++ b/parser/TechnologyValues.h
@@ -73,7 +73,7 @@ class TechnologyValues
     int technologynode;
 
     // size of DRAM
-    int dramsize;
+    float dramsize;
 
     // # of banks 
     int numberofbanks; 


### PR DESCRIPTION
Just think it may be useful to allow sub-Gb size in some cases, e.g., only modeling one internal vault of HMC. Plus this is just a small change that doesn't have much side effect.

If you don't like this, please simply reject it. :)