### PR TITLE
Updated bash scripts and README. Added unexpected case hadling to remove warnings. Implemented small help run if no argument is given.

### DIFF
--- a/DRAMSpec.pro
+++ b/DRAMSpec.pro
@@ -159,6 +159,8 @@ CONFIG(release, debug|release) {
     RCC_DIR = build/release/.rcc
     UI_DIR = build/release/.ui
 
+    QMAKE_CXXFLAGS += -Wextra -Wall
+
     SOURCES += main.cpp
 
     TARGET = dramspec

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ DRAMSpec requires some libraries from [boost](http://www.boost.org/). If you do 
 
 ### Building DRAMSpec
 
-1. To be sure DRAMSpec repository was properly cloned, build and run the program in test mode:
+1. To be sure DRAMSpec repository was properly cloned, build and run the program in test mode either by using the script below or compiling and running the debug version of the program manually. If chosen to do manually, make sure you run the executable directly from within the directory `build/debug`!
 
 ``` bash
     ./runTests.sh

--- a/buildDRAMSpec.sh
+++ b/buildDRAMSpec.sh
@@ -5,4 +5,6 @@ CALLDIR="`dirname "$script"`";
 cd ${CALLDIR};
 
 qmake CONFIG+=release DRAMSpec.pro;
+echo "Compiling...";
 make -s;
+echo "Ready!";

--- a/buildDRAMSpec.sh
+++ b/buildDRAMSpec.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+script="`readlink -f "${BASH_SOURCE[0]}"`"
+CALLDIR="`dirname "$script"`";
+cd ${CALLDIR};
+
 qmake CONFIG+=release DRAMSpec.pro;
 make -s;

--- a/parser/ArgumentsParser.cpp
+++ b/parser/ArgumentsParser.cpp
@@ -47,10 +47,33 @@ ArgumentsParser::ArgumentsParser(int argc, char** argv)
     argvID = 1;
     nConfigurations = 0;
     IOTerminationCurrentFlag = false;
+    helpMessage.str("");
 }
 
 void ArgumentsParser::runArgParser()
 {
+    // Help run
+    if ( cpargc == 1 ) {
+        helpMessage << "Parameters:"
+                    << endl;
+        helpMessage << "  Mandatory:"
+                    << endl;
+        helpMessage << "    -t    <path/to/technologyfile.json>   "
+                    << "(Specify which technology description file should be used.)"
+                    << endl;
+        helpMessage << "    -p    <path/to/architecturefile.json> "
+                    << "(Specify which architecture description file should be used.)"
+                    << endl;
+        helpMessage << "  Optional:"
+                    << endl;
+        helpMessage << "    -term                                 "
+                    << "(Include IO termination currents for read and write operations.)"
+                    << endl;
+        helpMessage << "For more information, see README.md."
+                    << endl;
+    }
+
+    // Normal run
     if ( argvID >= cpargc ) {
         return;
     }

--- a/parser/ArgumentsParser.h
+++ b/parser/ArgumentsParser.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <vector>
 #include <string>
+#include <sstream>
 
 using namespace std;
 
@@ -16,6 +17,8 @@ public:
     vector<string> architectureFileName;
     unsigned int nConfigurations;
     bool IOTerminationCurrentFlag;
+
+    ostringstream helpMessage;
 
     void runArgParser();
 

--- a/parser/DramSpec.cpp
+++ b/parser/DramSpec.cpp
@@ -297,6 +297,11 @@ void DRAMSpec::runDramSpec(int argc, char** argv)
         throw exceptionMsgThrown;
     }
 
+    if ( !arg->helpMessage.str().empty() ) {
+        output << arg->helpMessage.str();
+        return;
+    }
+
     output << "_______________________________________________________"
            << "_______________________________________________________"
            << "_______________________________________________________"

--- a/parser/DramSpec.cpp
+++ b/parser/DramSpec.cpp
@@ -223,6 +223,11 @@ DRAMSpec::arrangeOutput(const string outputType)
     else if (outputType == "stdout") {
         lineWidth = 30;
         separator = "";
+    } else {
+        std::string exceptionMsgThrown("[ERROR] ");
+        exceptionMsgThrown.append("Unexpected behaviour - ");
+        exceptionMsgThrown.append("could not decide on output type.");
+        throw exceptionMsgThrown;
     }
 
     ostringstream resultTable;
@@ -334,10 +339,18 @@ void DRAMSpec::runDramSpec(int argc, char** argv)
                       << "  Parameter filename: " << arg->architectureFileName[configID]
                       << endl;
 
-        csvResultFile << arrangeOutput("csv");
+        try {
+            csvResultFile << arrangeOutput("csv");
+        } catch(string exceptionMsgThrown) {
+            throw exceptionMsgThrown;
+        }
         csvResultFile.close();
 
-        output << arrangeOutput("stdout") << endl;
+        try {
+            output << arrangeOutput("stdout") << endl;
+        } catch(string exceptionMsgThrown) {
+            throw exceptionMsgThrown;
+        }
         output  << "_______________________________________________________"
                 << "_______________________________________________________"
                 << "_______________________________________________________"

--- a/runTests.sh
+++ b/runTests.sh
@@ -5,7 +5,9 @@ CALLDIR="`dirname "$script"`";
 cd ${CALLDIR};
 
 qmake CONFIG+=debug DRAMSpec.pro;
+echo "Compiling...";
 make -s;
 
 cd build/debug/;
+echo "Testing...";
 ./dramspec_test;

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+script="`readlink -f "${BASH_SOURCE[0]}"`"
+CALLDIR="`dirname "$script"`";
+cd ${CALLDIR};
+
 qmake CONFIG+=debug DRAMSpec.pro;
 make -s;
+
 cd build/debug/;
 ./dramspec_test;


### PR DESCRIPTION
First commit: Bash scripts are now able to be called for wherever (not only the main directory). Unit tests executable should still be called from within `build/debug`, though.

Second commit: Added code for unexpected case to remove warnings. I wasn't able to repeat the warnings even with the previous version, but I am pretty sure it should not show up anymore.

Third commit: Implemented straightforward instruction for using the program when no arguments are given.

Since I made each modification above the others, I am only opening one pull request. - My bad